### PR TITLE
Use valid service name to receive meeting state

### DIFF
--- a/TeamsClientApiSample/MeetingServicesConverter.cs
+++ b/TeamsClientApiSample/MeetingServicesConverter.cs
@@ -16,7 +16,7 @@ class MeetingServicesConverter : JsonConverter<MeetingService>
         string serializedValue = value switch
         {
             MeetingService.BackgroundBlur => "background-blur",
-            MeetingService.QueryMeetingState => "query_meeting_state",
+            MeetingService.QueryMeetingState => "query-meeting-state",
             MeetingService.RaiseHand => "raise-hand",
             MeetingService.Recording => "recording",
             MeetingService.ToggleMute => "toggle-mute",


### PR DESCRIPTION
Might be a typo, but `query_meeting_state` didn't work for me.